### PR TITLE
Removed reference of lexer using Lexer.clone()

### DIFF
--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -237,7 +237,9 @@
         // Read options
         this.options = {
             keepHistory: false,
-            lexer: grammar.lexer || new StreamLexer,
+            // Call clone to remove the reference
+            // But not at StreamLexer because StreamLexer is defined right here
+            grammar.lexer ? grammar.lexer.clone() : new StreamLexer,
         };
         for (var key in (options || {})) {
             this.options[key] = options[key];


### PR DESCRIPTION
By removing the reference, multiple parsers with custom lexers can be used at the same time